### PR TITLE
Add v8pp library

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@
 | [jni.hpp](https://github.com/mapbox/jni.hpp) | [![GitHub stars](https://img.shields.io/github/stars/mapbox/jni.hpp?style=social)](https://github.com/mapbox/jni.hpp/stargazers/) | A modern, type-safe, C++14 wrapper for JNI. | [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) |
 | [pybind11](https://github.com/pybind/pybind11) | [![GitHub stars](https://img.shields.io/github/stars/pybind/pybind11?style=social)](https://github.com/pybind/pybind11/stargazers/) | Seamless operability between C++11 and Python. | [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) |
 | [Selene](https://github.com/jeremyong/Selene) | [![GitHub stars](https://img.shields.io/github/stars/jeremyong/Selene?style=social)](https://github.com/jeremyong/Selene/stargazers/) | Simple C++11 friendly bindings to Lua. | [![License: Zlib](https://img.shields.io/badge/License-Zlib-lightgrey.svg)](https://opensource.org/licenses/Zlib) |
+| [v8pp](https://github.com/pmed/v8pp) | [![GitHub stars](https://img.shields.io/github/stars/pmed/v8pp?style=social)](https://github.com/pmed/v8pp/stargazers/) | Bind C++ functions and classes into V8 JavaScript engine. | [![License](https://img.shields.io/badge/License-Boost%201.0-lightblue.svg)](https://www.boost.org/LICENSE_1_0.txt) |
 
 ## Logging
 


### PR DESCRIPTION
Header-only library to expose C++ classes and functions into V8 to use them in JavaScript code. v8pp uses heavy template metaprogramming and variadic template parameters which requires modern compiler with C++11 support. There is also C++17 version in development.