### PR TITLE
Add travis ci for validating links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+# https://github.com/dkhamsing/awesome_bot/
+language: ruby
+rvm:
+  - 2.2
+before_script:
+  - gem install awesome_bot
+script:
+  - awesome_bot README.md --allow-dupe --allow-redirect --skip-save-results


### PR DESCRIPTION
Although the links in README.md are hardly going to break, having a validation is nevertheless useful. To that, I have explored github actions and travis with [awesome_bot](https://github.com/dkhamsing/awesome_bot). Github actions threw HTTP error 429( Too many requests ) on my trials. Everything worked fine with Travis.

You might have to allow travis to access the repo in order to enable checks.