### PR TITLE
Added `sfl::pool_allocator`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@
 
 | Library  | Stars |  Description | License  |
 |--- | ---| ---|--- |
+| [sfl::pool_allocator](https://github.com/slavenf/sfl-pool-allocator)  | [![GitHub stars](https://img.shields.io/github/stars/slavenf/sfl-pool-allocator?style=social)](https://github.com/slavenf/sfl-pool-allocator/stargazers/) | C++11 memory allocator based on memory pools. | [![License: Zlib](https://img.shields.io/badge/License-Zlib-lightgrey.svg)](https://opensource.org/licenses/Zlib) |
 | [ugc](https://github.com/bullno1/ugc) | [![GitHub stars](https://img.shields.io/github/stars/bullno1/ugc?style=social)](https://github.com/bullno1/ugc/stargazers/) | Incremental garbage collector. | [![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause) |
 
 ## Mocking


### PR DESCRIPTION
This is C++11 memory allocator based on memory pools.
It offers fast and efficient allocation of a large number of small-size objects.

This library consists of one .hpp file and one .cpp file so this is not header-only library in the full sense of that word, but this library behaves as header-only library with two header files -- The user **must copy-paste both** .hpp and .cpp files in its own project and compile them **together** with its own project.

I am not sure whether such library is allowed or not. It is up to you to decide.