### PR TITLE
Add Noise2D

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@
 | [color-util](https://github.com/yuki-koyama/color-util) | [![GitHub stars](https://img.shields.io/github/stars/yuki-koyama/color-util?style=social)](https://github.com/yuki-koyama/color-util/stargazers/) | Colors, Color space converters for RGB, HSL, XYZ, Lab, etc. | [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) |
 | [color](https://github.com/dmilos/color) | [![GitHub stars](https://img.shields.io/github/stars/dmilos/color?style=social)](https://github.com/dmilos/color/stargazers/) | Color manipulation/conversion for different types and formats. | [![License: MIT](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) |
 | [nanopm](https://github.com/unclearness/nanopm) | [![GitHub stars](https://img.shields.io/github/stars/unclearness/nanopm?style=social)](https://github.com/unclearness/nanopm/stargazers/) | NanoPM, single header only PatchMatch. | |
+| [noise2d](https://github.com/conwe007/noise2d) | [![GitHub stars](https://img.shields.io/github/stars/conwe007/noise2d?style=social)](https://github.com/conwe007/noise2d/stargazers/) | 2D Noise generation for C++17 and later. | [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) |
 
 ## Language Bindings
 


### PR DESCRIPTION
Noise2D is a C++17 header-only library for generating 2D noise. It has no dependencies outside the standard library. It can generate white noise, brown noise, or blue noise.