### PR TITLE
Add Conex – single-header binary pattern matching library

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@
 
 | Library  | Stars |  Description | License  |
 |--- | ---| ---|--- |
+| [Conex](https://github.com/DanielCohen197/Conex) | [![GitHub stars](https://img.shields.io/github/stars/DanielCohen197/Conex?style=social)](https://github.com/DanielCohen197/Conex/stargazers/) | Single-header C++20 library for condition-based binary pattern matching with regex-style syntax and lambda conditions. | [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) |
 | [cpp-peglib](https://github.com/yhirose/cpp-peglib) | [![GitHub stars](https://img.shields.io/github/stars/yhirose/cpp-peglib?style=social)](https://github.com/yhirose/cpp-peglib/stargazers/) | PEG (Parsing Expression Grammars) library. | [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) |
 | [lug](https://github.com/jwtowner/lug) | [![GitHub stars](https://img.shields.io/github/stars/jwtowner/lug?style=social)](https://github.com/jwtowner/lug/stargazers/) | A C++17 embedded domain specific language for expressing parsers as extended PEG. | [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) |
 | [PEGTL](https://github.com/taocpp/PEGTL) | [![GitHub stars](https://img.shields.io/github/stars/taocpp/PEGTL?style=social)](https://github.com/taocpp/PEGTL/stargazers/) | Parsing Expression Grammar Template Library. | [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) |


### PR DESCRIPTION
Adding Conex, a single-header C++20 library for condition-based binary pattern matching.

- Single header, no dependencies
- Regex-style pattern syntax: (c0:4)(c1:8)*
- Each group is a lambda that inspects raw bytes
- Supports *, +, ? quantifiers with backtracking and captures
- MIT licensed, CI passing on GCC/Clang/MSVC

https://github.com/DanielCohen197/Conex